### PR TITLE
fix: remove automatic account enable

### DIFF
--- a/app.js
+++ b/app.js
@@ -95,7 +95,6 @@ async function getShieldedAccounts(req) {
 
 async function newAccount() {
   const ethAccount = await walletManager.newAccount('users');
-  await tradeManager.cashTokenClient.enableAccount(ethAccount.address);
   const shieldedAccount = await shieldedWallet.createAccount(ethAccount.address);
   return { eth: ethAccount.address, shielded: shieldedAccount };
 }

--- a/lib/trade-manager/zether-token.js
+++ b/lib/trade-manager/zether-token.js
@@ -26,6 +26,7 @@ const Web3Utils = require('web3-utils');
 const bn128 = require('@anonymous-zether/anonymous.js/src/utils/bn128');
 const bn128Utils = require('@anonymous-zether/anonymous.js/src/utils/utils');
 
+const Authority = require('../keystore/authority');
 const { BaseClient, locateFunctionOrEvent } = require('../base');
 const { OneTimeSignersWallet } = require('../keystore/hdwallet');
 const Config = require('../config');
@@ -44,6 +45,7 @@ class ZetherTokenClient extends BaseClient {
     this.walletManager.addWallet(ONETIME_KEYS, this.hdwallet);
     this.shieldedWallet = shieldedWallet;
     this.cashTokenClient = cashTokenClient;
+    this.authority = Authority.getAccount(this.web3);
   }
 
   async init() {
@@ -78,14 +80,12 @@ class ZetherTokenClient extends BaseClient {
     logger.info(`Registering shielded account ${shieldedAccount} with the ZSC contract`);
     const func = locateFunctionOrEvent(zscABI, 'register');
     const args = [bn128.serialize(account.address), c, s, Web3Utils.fromAscii(name)];
-    let oneTimeAccount;
     try {
-      oneTimeAccount = await this.walletManager.newAccount(ONETIME_KEYS);
-      const receipt = await this.sendTransaction(zsc, oneTimeAccount.address, func, args);
+      const receipt = await this.sendTransaction(zsc, this.authority.address, func, args, { isAdminSigner: true });
       logger.info(`Successfully registered shielded account ${shieldedAccount} with ZSC contract. (transactionHash: ${receipt.transactionHash})`);
       return receipt.transactionHash;
     } catch (err) {
-      await this.handleTxError(func, args, oneTimeAccount.address, err);
+      await this.handleTxError(func, args, this.authority.address, err);
       throw new HttpError(`Failed to register ${shieldedAccount}`, 500);
     }
   }


### PR DESCRIPTION
Hello everyone, the following change is necessary due to a recently added rule that only participants' addresses can register a zether account and it was necessary to remove automatic account enablement as participants do not have permission to enable accounts in the real digital.