### PR TITLE
fix: changed the response to not omit duplicate names

### DIFF
--- a/lib/trade-manager/zether-token.js
+++ b/lib/trade-manager/zether-token.js
@@ -101,7 +101,7 @@ class ZetherTokenClient extends BaseClient {
       logger.error(`Failed to call getRegsiteredAccounts(). ${err}`);
       throw new HttpError('Failed to call getRegsiteredAccounts()');
     }
-    const accounts = {};
+    const accounts = [];
     for (let entry of registeredAccounts) {
       let name;
       try {
@@ -109,7 +109,7 @@ class ZetherTokenClient extends BaseClient {
       } catch (_error) {
         name = Web3Utils.toAscii(entry.name);
       }
-      accounts[name] = entry.shieldedAddress;
+      accounts.push({ name, address: entry.shieldedAddress });
     }
     return accounts;
   }


### PR DESCRIPTION
It was necessary to change `accounts` to a list so as not to overwrite the key that was represented by `name`.